### PR TITLE
Fix typo and add robots test

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ All commands are run from the root of the project, from a terminal:
 | `npm run dev`             | Starts local dev server at `localhost:4321`      |
 | `npm run build`           | Build your production site to `./dist/`          |
 | `npm run preview`         | Preview your build locally, before deploying     |
+| `npm test`                | Run the project tests                            |
 | `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `npm run astro -- --help` | Get help using the Astro CLI                     |
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "node --test"
   },
   "dependencies": {
     "@astrojs/alpinejs": "^0.4.8",

--- a/src/lib/robots.js
+++ b/src/lib/robots.js
@@ -1,0 +1,3 @@
+export function getRobotsTxt(sitemapURL) {
+  return `User-agent: *\nAllow: /\n\nSitemap: ${sitemapURL.href}\n`;
+}

--- a/src/pages/apply-tailwind.astro
+++ b/src/pages/apply-tailwind.astro
@@ -126,7 +126,7 @@ const {
 		border: 1px solid var(--surface-2);
 	}
 	
-	.pallette {
+	.palette {
 			/* Stack space */
 			--space: var(--spacing-xs);
 			display: flex;
@@ -156,12 +156,12 @@ const {
 		}
 	
 	
-	.nested-pallette { 
+	.nested-palette { 
 		max-width: 55%;
 		background-color: var(--color-surface-0); 
 		border-radius: var(--radius-md);
 	}
-	.nested-pallette div {
+	.nested-palette div {
 		padding: var(--spacing-xs);
 		margin: var(--spacing-sm);
 		border-radius: var(--radius-md);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,7 +20,7 @@ const {
 	    <p>This color scheme and font represents your brand.</p>
 	
 	    <h2 class="text-md">Theme colors</h2>
-	    <ul role="list" class="pallette theme scroll-x-overflow" style="--overflow-space: 0;">
+	    <ul role="list" class="palette theme scroll-x-overflow" style="--overflow-space: 0;">
         <li>
           <span class="swatch bg-brand-4"></span>
           <span>--brand-1</span>
@@ -49,7 +49,7 @@ const {
 
 	    <h2 class="text-md">Grayscale</h2>
       
-      <ul role="list" class="flex	pallette grayscale">
+      <ul role="list" class="flex	palette grayscale">
         <li>
           <span class="swatch bg-surface-1"></span>
           <span>--surface-1</span>
@@ -70,7 +70,7 @@ const {
 
 	    <h2 class="text-md">Text</h2>
       
-      <ul role="list" class="flex	pallette text">
+      <ul role="list" class="flex	palette text">
         <li>
           <span class="swatch bg-text-1"></span>
           <span>--text-1</span>
@@ -82,7 +82,7 @@ const {
       </ul>
 
 	<h2 class="text-md">Alert Colors</h2>
-	<ul role="list" class="flex	pallette alert">
+	<ul role="list" class="flex	palette alert">
 		<li>
 			<span class="swatch bg-danger"></span>
 			<span>--danger</span>
@@ -101,7 +101,7 @@ const {
 		</li>
 	</ul>
 
-	<div class="nested-pallette">
+	<div class="nested-palette">
 		<div style="background-color: var(--color-surface-1)">
 			<span>var(--surface-1)</span>
 			<div style="background-color: var(--color-surface-2)">
@@ -215,7 +215,7 @@ const {
 		border: 1px solid var(--surface-2);
 	}
 	
-	.pallette {
+	.palette {
 		/* Stack space */
 		--space: var(--spacing-xs);
 		display: flex;
@@ -228,12 +228,12 @@ const {
 		gap: var(--spacing-xs);
 	}
 
-	.nested-pallette { 
+	.nested-palette { 
 		max-width: 55%;
 		background-color: var(--color-surface-0); 
 		border-radius: var(--radius-md);
 	}
-	.nested-pallette div {
+	.nested-palette div {
 		padding: var(--spacing-xs);
 		margin: var(--spacing-sm);
 		border-radius: var(--radius-md);

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,11 +1,5 @@
 import type { APIRoute } from 'astro';
-
-const getRobotsTxt = (sitemapURL: URL) => `
-User-agent: *
-Allow: /
-
-Sitemap: ${sitemapURL.href}
-`;
+import { getRobotsTxt } from '../lib/robots.js';
 
 export const GET: APIRoute = ({ site }) => {
   const sitemapURL = new URL('sitemap-index.xml', site);

--- a/test/robots.test.js
+++ b/test/robots.test.js
@@ -1,0 +1,7 @@
+import assert from 'assert';
+import { getRobotsTxt } from '../src/lib/robots.js';
+
+assert.strictEqual(
+  getRobotsTxt(new URL('https://example.com/sitemap.xml')),
+  `User-agent: *\nAllow: /\n\nSitemap: https://example.com/sitemap.xml\n`
+);


### PR DESCRIPTION
## Summary
- fix palette typo in pages
- factor out robots helper for easier testing
- add Node test for robots helper
- document the test command in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68410e04ffa48330a28c5c1f6d292985