### PR TITLE
Fix Select component type

### DIFF
--- a/src/components/Select.astro
+++ b/src/components/Select.astro
@@ -1,6 +1,11 @@
 ---
 import type { HTMLAttributes } from 'astro/types';
 
+interface Option {
+  value: string;
+  label: string;
+}
+
 interface Props extends HTMLAttributes<'select'> {
   label: string;
   uid?: string;


### PR DESCRIPTION
## Summary
- define missing `Option` interface in `Select.astro`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684110bfa8e48330803d519c69095151