### PR TITLE
Add sample MDX blog

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -1,0 +1,10 @@
+---
+import Layout from './Layout.astro';
+const { title = 'Blog', description = 'Blog posts' } = Astro.props;
+---
+
+<Layout {title} {description}>
+  <main class="p-inline-max py-lg stack stack-md">
+    <slot />
+  </main>
+</Layout>

--- a/src/pages/blog/categories/[category].astro
+++ b/src/pages/blog/categories/[category].astro
@@ -1,0 +1,15 @@
+---
+import BlogLayout from '../../../layouts/BlogLayout.astro';
+const { params } = Astro;
+const posts = await Astro.glob('../*.mdx');
+const filtered = posts.filter(p => p.frontmatter.category.toLowerCase() === params.category.toLowerCase());
+---
+
+<BlogLayout title={`Category: ${params.category}`} description={`Posts in ${params.category}`}>
+  <h1>Category: {params.category}</h1>
+  <ul>
+    {filtered.map(post => (
+      <li><a href={post.url}>{post.frontmatter.title}</a></li>
+    ))}
+  </ul>
+</BlogLayout>

--- a/src/pages/blog/categories/index.astro
+++ b/src/pages/blog/categories/index.astro
@@ -1,0 +1,14 @@
+---
+import BlogLayout from '../../../layouts/BlogLayout.astro';
+const posts = await Astro.glob('../*.mdx');
+const categories = Array.from(new Set(posts.map(p => p.frontmatter.category)));
+---
+
+<BlogLayout title="Categories" description="Blog categories">
+  <h1>Categories</h1>
+  <ul>
+    {categories.map(cat => (
+      <li><a href={`./${cat.toLowerCase()}/`}>{cat}</a></li>
+    ))}
+  </ul>
+</BlogLayout>

--- a/src/pages/blog/first-post.mdx
+++ b/src/pages/blog/first-post.mdx
@@ -1,0 +1,12 @@
+---
+title: "Hello World"
+description: "First blog post"
+pubDate: 2023-10-01
+category: General
+tags:
+  - intro
+  - welcome
+layout: ../../layouts/BlogLayout.astro
+---
+
+Welcome to my blog! This is the first post written in **MDX**.

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,36 @@
+---
+import BlogLayout from '../../layouts/BlogLayout.astro';
+const posts = await Astro.glob('./*.mdx');
+posts.sort((a, b) => new Date(b.frontmatter.pubDate) - new Date(a.frontmatter.pubDate));
+
+const categories = Array.from(new Set(posts.map(p => p.frontmatter.category)));
+const tagSet = new Set();
+posts.forEach(p => (p.frontmatter.tags || []).forEach(t => tagSet.add(t)));
+const tags = [...tagSet];
+---
+
+<BlogLayout title="Blog" description="Blog posts">
+  <h1>Blog</h1>
+  <ul>
+    {posts.map(post => (
+      <li>
+        <a href={post.url}>{post.frontmatter.title}</a>
+        <p>{post.frontmatter.description}</p>
+      </li>
+    ))}
+  </ul>
+
+  <h2>Categories</h2>
+  <ul>
+    {categories.map(cat => (
+      <li><a href={`./categories/${cat.toLowerCase()}/`}>{cat}</a></li>
+    ))}
+  </ul>
+
+  <h2>Tags</h2>
+  <ul>
+    {tags.map(tag => (
+      <li><a href={`./tags/${tag.toLowerCase()}/`}>{tag}</a></li>
+    ))}
+  </ul>
+</BlogLayout>

--- a/src/pages/blog/second-post.mdx
+++ b/src/pages/blog/second-post.mdx
@@ -1,0 +1,12 @@
+---
+title: "Another Post"
+description: "Follow-up post"
+pubDate: 2023-10-15
+category: Updates
+tags:
+  - news
+  - update
+layout: ../../layouts/BlogLayout.astro
+---
+
+This is another post to demonstrate categories and tags in our **Astro** blog.

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -1,0 +1,15 @@
+---
+import BlogLayout from '../../../layouts/BlogLayout.astro';
+const { params } = Astro;
+const posts = await Astro.glob('../*.mdx');
+const filtered = posts.filter(p => (p.frontmatter.tags || []).map(t => t.toLowerCase()).includes(params.tag.toLowerCase()));
+---
+
+<BlogLayout title={`Tag: ${params.tag}`} description={`Posts tagged ${params.tag}`}>
+  <h1>Tag: {params.tag}</h1>
+  <ul>
+    {filtered.map(post => (
+      <li><a href={post.url}>{post.frontmatter.title}</a></li>
+    ))}
+  </ul>
+</BlogLayout>

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -1,0 +1,16 @@
+---
+import BlogLayout from '../../../layouts/BlogLayout.astro';
+const posts = await Astro.glob('../*.mdx');
+const tagSet = new Set();
+posts.forEach(p => (p.frontmatter.tags || []).forEach(t => tagSet.add(t)));
+const tags = [...tagSet];
+---
+
+<BlogLayout title="Tags" description="Blog tags">
+  <h1>Tags</h1>
+  <ul>
+    {tags.map(tag => (
+      <li><a href={`./${tag.toLowerCase()}/`}>{tag}</a></li>
+    ))}
+  </ul>
+</BlogLayout>


### PR DESCRIPTION
## Summary
- add `BlogLayout` layout
- add MDX blog posts with category and tag metadata
- list posts in `blog/index.astro`
- add category and tag index pages and dynamic routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68426a52fe8c83308a977807950d9f11