### PR TITLE
Fix blog routes 404

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,10 +1,15 @@
 ---
-import { getEntryBySlug } from 'astro:content';
+import { getCollection, getEntryBySlug } from 'astro:content';
 import BlogLayout from '../../layouts/BlogLayout.astro';
 const { slug } = Astro.params;
 const post = await getEntryBySlug('blog', slug);
 if (!post) throw new Error(`Post not found: ${slug}`);
 const { Content, data } = await post.render();
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map(post => ({ params: { slug: post.slug } }));
+}
 ---
 <BlogLayout title={data.title} description={data.description}>
   <Content />

--- a/src/pages/blog/categories/[category].astro
+++ b/src/pages/blog/categories/[category].astro
@@ -4,6 +4,12 @@ import { getCollection } from 'astro:content';
 const { params } = Astro;
 const posts = await getCollection('blog');
 const filtered = posts.filter(p => p.data.category.toLowerCase() === params.category.toLowerCase());
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  const categories = Array.from(new Set(posts.map(p => p.data.category)));
+  return categories.map(category => ({ params: { category: category.toLowerCase() } }));
+}
 ---
 
 <BlogLayout title={`Category: ${params.category}`} description={`Posts in ${params.category}`}>

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -4,6 +4,13 @@ import { getCollection } from 'astro:content';
 const { params } = Astro;
 const posts = await getCollection('blog');
 const filtered = posts.filter(p => (p.data.tags || []).map(t => t.toLowerCase()).includes(params.tag.toLowerCase()));
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  const tagSet = new Set();
+  posts.forEach(p => (p.data.tags || []).forEach(t => tagSet.add(t.toLowerCase())));
+  return Array.from(tagSet).map(tag => ({ params: { tag } }));
+}
 ---
 
 <BlogLayout title={`Tag: ${params.tag}`} description={`Posts tagged ${params.tag}`}>


### PR DESCRIPTION
## Summary
- generate static paths for dynamic blog routes so the blog works in SSG mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842d51a6e408330aa4bc9b29bf731e1